### PR TITLE
Update install-jars script

### DIFF
--- a/support/install-jars
+++ b/support/install-jars
@@ -18,11 +18,15 @@ cd /tmp/jars
 if [ ! -f saxon9he.jar ]; then
     wget http://central.maven.org/maven2/net/sf/saxon/Saxon-HE/9.8.0-2/Saxon-HE-9.8.0-2.jar
     mv Saxon-HE-9.8.0-2.jar saxon9he.jar
+else
+    echo "/tmp/jars/saxon9he.jar exists. To force a re-download, delete it manually and re-run this script. "
 fi
 
 if [ ! -f trang.jar ]; then
     wget http://central.maven.org/maven2/com/thaiopensource/trang/20091111/trang-20091111.jar
     mv trang-20091111.jar trang.jar
+else
+    echo "/tmp/jars/trang.jar exists. To force a re-download, delete it manually and re-run this script. "
 fi
 
 cd $BUILD


### PR DESCRIPTION
This PR adds a warning to the install-jars script to inform the caller when a specific jar file already exists. This should prevent issues like #66 in the future.